### PR TITLE
Fix Warning: Accessing PropTypes via React package is deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "peerDependencies": {
     "immutable": "*",
-    "react": "*"
+    "prop-types": "*"
   },
   "devDependencies": {
     "babel": "^6.3.26",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import {PropTypes} from 'react'
+import PropTypes from 'prop-types'
 import Immutable from 'immutable'
 import Cursor from 'immutable/contrib/cursor'
 


### PR DESCRIPTION
Use the prop-types package from npm instead.